### PR TITLE
#1 headerコンポーネントを設置

### DIFF
--- a/src/components/organisms/Header/index.tsx
+++ b/src/components/organisms/Header/index.tsx
@@ -5,7 +5,7 @@ import { colors } from 'src/styles/Tokens';
 import Link from 'next/link';
 
 const Wrapper = styled.header`
-  width: 100%;
+  width: 100vw;
   padding: 8px 0;
   background-color: ${colors.White};
   display: flex;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,25 +1,34 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import Image from 'next/image';
+import { Header } from 'src/components/organisms/Header';
 
 import { Container, Main, Title, TokenTest } from 'src/styles/Home';
 
 const Home: NextPage = () => (
-  <Container>
+  <>
     <Head>
       <title>Yumeshop</title>
       <meta name="description" content="" />
       <link rel="icon" href="/favicon.ico" />
     </Head>
-
+    <Header />
     <Main>
-      <Image src="/shopping-bag.jpg" alt="買い物袋" width={600} height={600} />
+      <Container>
+        <Image
+          src="/shopping-bag.jpg"
+          alt="買い物袋"
+          width={600}
+          height={600}
+        />
 
-      <TokenTest>
-        <Title>Welcome to Yumeshop</Title>
-      </TokenTest>
+        <TokenTest>
+          <Title>Welcome to Yumeshop</Title>
+        </TokenTest>
+      </Container>
     </Main>
-  </Container>
+    ß
+  </>
 );
 
 export default Home;


### PR DESCRIPTION
# 概要
headerコンポーネントの作成
ContainerスタイルをMainスタイル内に移動することで、headerを画面幅いっぱいに広げるようにした。

# デモ
<img width="1045" alt="スクリーンショット 2023-01-23 14 19 11" src="https://user-images.githubusercontent.com/81739310/213970597-20ce3158-5609-4aac-a0dc-e426b8526b22.png">


# レビューレベル

- [ ] Lv0: まったく見ないでAcceptする

- [ ] Lv1: ぱっとみて違和感がないかチェックしてAcceptする

- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証してAcceptする

- [ ] LV3: 実際に環境で動作確認したうえでAcceptする

# 関連チケット
#1 

# 注意点