### PR TITLE
Feat/create simple card organisms

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "next": "13.0.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-image-gallery": "^1.2.11"
+    "react-image-gallery": "^1.2.11",
+    "react-uuid": "^2.0.0"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^13.0.7",

--- a/src/components/atoms/SimpleCard/index.stories.tsx
+++ b/src/components/atoms/SimpleCard/index.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, Story } from '@storybook/react/types-6-0';
+import uuid from 'react-uuid';
 import { SimpleCard } from './index';
 
 export default {
@@ -7,12 +8,13 @@ export default {
 } as Meta;
 
 const props = {
+  id: uuid(),
   image: 'https://picsum.photos/id/1019/1000/600/',
   title:
     'ゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめ',
   path: '/shop_items'
 };
 
-const Template: Story = () => <SimpleCard image={props.image} title={props.title} path={props.path} />;
+const Template: Story = () => <SimpleCard id={props.id} image={props.image} title={props.title} path={props.path} />;
 
 export const simpleCard = Template.bind({});

--- a/src/components/atoms/SimpleCard/index.tsx
+++ b/src/components/atoms/SimpleCard/index.tsx
@@ -11,22 +11,25 @@ export interface SimpleCardProps {
 }
 
 const Wrapper = styled.div`
-  margin: 16px 4px;
   background: #ffffff;
   box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.25);
-  max-width: 244px;
-  min-width: 244px;
-  min-height: 56px;
   overflow: hidden;
   border-radius: 8px;
-  flex-grow: 1;
+  min-width: 200px;
+  width: 200px;
+  @media (min-width: 1152px) {
+    min-width: 244px;
+    width: 244px;
+  }
 `;
 const ImageWrapper = styled.div`
   position: relative;
   aspect-ratio: 16/9;
+
 `;
 const TitleWrapper = styled.p`
   padding: 12px 8px;
+  min-height: 48px;
 `;
 
 export const SimpleCard: VFC<SimpleCardProps> = (props) => {
@@ -35,10 +38,10 @@ export const SimpleCard: VFC<SimpleCardProps> = (props) => {
     <Wrapper>
       <Link href={path}>
         <>
-        <ImageWrapper>
-          <Image src={image} alt={title} fill />
-        </ImageWrapper>
-        <TitleWrapper>{title}</TitleWrapper>
+          <ImageWrapper>
+            <Image src={image} alt={title} fill />
+          </ImageWrapper>
+          <TitleWrapper>{title}</TitleWrapper>
         </>
       </Link>
     </Wrapper>

--- a/src/components/atoms/SimpleCard/index.tsx
+++ b/src/components/atoms/SimpleCard/index.tsx
@@ -3,7 +3,8 @@ import Link from 'next/link';
 import { VFC } from 'react';
 import styled from 'styled-components';
 
-interface SimpleCardProps {
+export interface SimpleCardProps {
+  id: string;
   image: string;
   title: string;
   path: string;
@@ -14,9 +15,11 @@ const Wrapper = styled.div`
   background: #ffffff;
   box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.25);
   max-width: 244px;
-  min-width: 200px;
+  min-width: 244px;
+  min-height: 56px;
   overflow: hidden;
   border-radius: 8px;
+  flex-grow: 1;
 `;
 const ImageWrapper = styled.div`
   position: relative;
@@ -29,13 +32,15 @@ const TitleWrapper = styled.p`
 export const SimpleCard: VFC<SimpleCardProps> = (props) => {
   const { image, title, path } = props;
   return (
-    <Link href={path}>
-      <Wrapper>
+    <Wrapper>
+      <Link href={path}>
+        <>
         <ImageWrapper>
           <Image src={image} alt={title} fill />
         </ImageWrapper>
         <TitleWrapper>{title}</TitleWrapper>
-      </Wrapper>
-    </Link>
+        </>
+      </Link>
+    </Wrapper>
   );
 };

--- a/src/components/organisms/SimpleCardSection/index.stories.tsx
+++ b/src/components/organisms/SimpleCardSection/index.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import uuid from 'react-uuid';
+import { SimpleCardSection, SimpleCardSectionProps } from './index';
+
+export default {
+  component: SimpleCardSection,
+  title: 'organisms/simpleCardSection',
+} as Meta;
+
+const Template: Story<SimpleCardSectionProps> = (args) => (
+  <SimpleCardSection {...args} />
+);
+
+export const Campaign = Template.bind({});
+Campaign.args = {
+  heading: 'キャンペーン',
+  simpleCardArray: [
+    {
+      id: uuid(),
+      image: 'https://picsum.photos/id/1019/1000/600/',
+      title: 'ゆめゆめみゆめみ',
+      path: '/shop_items',
+    },
+    {
+      id: uuid(),
+      image: 'https://picsum.photos/id/1019/1000/600/',
+      title:
+        'ゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめ',
+      path: '/shop_items/1',
+    },
+    {
+      id: uuid(),
+      image: 'https://picsum.photos/id/1019/1000/600/',
+      title: 'ゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめ',
+      path: '/shop_items/2',
+    },
+    {
+      id: uuid(),
+      image: 'https://picsum.photos/id/1019/1000/600/',
+      title:
+        'ゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆめみゆ',
+      path: '/shop_items/2',
+    },
+  ],
+};

--- a/src/components/organisms/SimpleCardSection/index.tsx
+++ b/src/components/organisms/SimpleCardSection/index.tsx
@@ -10,6 +10,8 @@ export interface SimpleCardSectionProps {
 
 const SimpleCardWrapper = styled.div`
   display: flex;
+  gap: 16px;
+  padding: 16px 0px;
   align-items: stretch;
   overflow-x: scroll;
   width: 320px;
@@ -21,6 +23,7 @@ const SimpleCardWrapper = styled.div`
   }
   @media (min-width: 1152px) {
     width: 100%;
+    flex-wrap: wrap;
   }
 
   ::-webkit-slider {

--- a/src/components/organisms/SimpleCardSection/index.tsx
+++ b/src/components/organisms/SimpleCardSection/index.tsx
@@ -1,0 +1,49 @@
+import { VFC } from 'react';
+import { Headline } from 'src/components/atoms/Headline';
+import { SimpleCard, SimpleCardProps } from 'src/components/atoms/SimpleCard';
+import styled from 'styled-components';
+
+export interface SimpleCardSectionProps {
+  heading: string;
+  simpleCardArray: SimpleCardProps[];
+}
+
+const SimpleCardWrapper = styled.div`
+  display: flex;
+  align-items: stretch;
+  overflow-x: scroll;
+  width: 320px;
+  @media (min-width: 375px) {
+    width: 359px;
+  }
+  @media (min-width: 768px) {
+    width: 768px;
+  }
+  @media (min-width: 1152px) {
+    width: 100%;
+  }
+
+  ::-webkit-slider {
+    display: none;
+  }
+`;
+
+export const SimpleCardSection: VFC<SimpleCardSectionProps> = (props) => {
+  const { heading, simpleCardArray } = props;
+  return (
+    <section>
+      <Headline label={heading} headlineTypes="middle" />
+      <SimpleCardWrapper>
+        {simpleCardArray.map((simpleCardItem: SimpleCardProps) => (
+          <SimpleCard
+            id={simpleCardItem.id}
+            image={simpleCardItem.image}
+            title={simpleCardItem.title}
+            path={simpleCardItem.path}
+            key={simpleCardItem.id}
+          />
+        ))}
+      </SimpleCardWrapper>
+    </section>
+  );
+};

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -4,25 +4,37 @@ export const exampleCampaignMock = [
   {
     id: uuid(),
     image: 'https://picsum.photos/id/1019/1000/600/',
-    title: 'ゆめみゆめみゆめみゆめみゆめみゆ',
+    title: 'ゆめみゆめみ',
     path: '/shop_items',
   },
   {
     id: uuid(),
     image: 'https://picsum.photos/id/1019/1000/600/',
-    title: 'ゆめゆめみゆめみゆめみゆめゆめめ',
+    title: 'ゆめゆめ',
     path: '/shop_items',
   },
   {
     id: uuid(),
     image: 'https://picsum.photos/id/1019/1000/600/',
-    title: 'ゆめみゆめみゆ',
+    title: 'ゆめみゆめみゆゆめみゆめみゆゆめみゆめみゆゆめみゆめみゆ',
     path: '/shop_items',
   },
   {
     id: uuid(),
     image: 'https://picsum.photos/id/1019/1000/600/',
-    title: '',
+    title: 'ゆめみゆめみゆゆめみゆめみゆ',
+    path: '/shop_items',
+  },
+  {
+    id: uuid(),
+    image: 'https://picsum.photos/id/1019/1000/600/',
+    title: 'ゆめみゆめみゆゆめみゆめみゆゆめみゆめみゆ',
+    path: '/shop_items',
+  },
+  {
+    id: uuid(),
+    image: 'https://picsum.photos/id/1019/1000/600/',
+    title: 'ゆめみゆめみゆゆめみゆめみゆ',
     path: '/shop_items',
   },
 ];
@@ -49,7 +61,7 @@ export const exampleCategoryMock = [
   {
     id: uuid(),
     image: 'https://picsum.photos/id/1019/1000/600/',
-    title: '',
+    title: 'ゆめみゆめみゆ',
     path: '/shop_items',
   },
 ];

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,0 +1,55 @@
+import uuid from "react-uuid";
+
+export const exampleCampaignMock = [
+  {
+    id: uuid(),
+    image: 'https://picsum.photos/id/1019/1000/600/',
+    title: 'ゆめみゆめみゆめみゆめみゆめみゆ',
+    path: '/shop_items',
+  },
+  {
+    id: uuid(),
+    image: 'https://picsum.photos/id/1019/1000/600/',
+    title: 'ゆめゆめみゆめみゆめみゆめゆめめ',
+    path: '/shop_items',
+  },
+  {
+    id: uuid(),
+    image: 'https://picsum.photos/id/1019/1000/600/',
+    title: 'ゆめみゆめみゆ',
+    path: '/shop_items',
+  },
+  {
+    id: uuid(),
+    image: 'https://picsum.photos/id/1019/1000/600/',
+    title: '',
+    path: '/shop_items',
+  },
+];
+
+export const exampleCategoryMock = [
+  {
+    id: uuid(),
+    image: 'https://picsum.photos/id/1019/1000/600/',
+    title: 'ゆめみゆめみゆめみゆめみゆめみゆ',
+    path: '/shop_items',
+  },
+  {
+    id: uuid(),
+    image: 'https://picsum.photos/id/1019/1000/600/',
+    title: 'ゆめゆめみゆめみゆめみゆめゆめめ',
+    path: '/shop_items',
+  },
+  {
+    id: uuid(),
+    image: 'https://picsum.photos/id/1019/1000/600/',
+    title: 'ゆめみゆめみゆ',
+    path: '/shop_items',
+  },
+  {
+    id: uuid(),
+    image: 'https://picsum.photos/id/1019/1000/600/',
+    title: '',
+    path: '/shop_items',
+  },
+];

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,14 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import Image from 'next/image';
+import uuid from 'react-uuid';
 import { Header } from 'src/components/organisms/Header';
+import { SimpleCardSection } from 'src/components/organisms/SimpleCardSection';
+import { exampleCampaignMock, exampleCategoryMock } from 'src/mocks';
 
 import { Container, Main, Title, TokenTest } from 'src/styles/Home';
+
+
 
 const Home: NextPage = () => (
   <>
@@ -15,16 +20,8 @@ const Home: NextPage = () => (
     <Header />
     <Main>
       <Container>
-        <Image
-          src="/shopping-bag.jpg"
-          alt="買い物袋"
-          width={600}
-          height={600}
-        />
-
-        <TokenTest>
-          <Title>Welcome to Yumeshop</Title>
-        </TokenTest>
+        <SimpleCardSection heading="キャンペーン" simpleCardArray={exampleCampaignMock} />
+        <SimpleCardSection heading="カテゴリー" simpleCardArray={exampleCategoryMock} />
       </Container>
     </Main>
     ß

--- a/src/styles/Home.ts
+++ b/src/styles/Home.ts
@@ -6,12 +6,18 @@ export const TokenTest = styled.div`
 `;
 
 export const Container = styled.div`
-  padding: 0 2rem;
+  padding: 0 16px;
+
+  @media (min-width: 768px) {
+    padding: 0 32px;
+  }
+  @media (min-width: 1152px) {
+    padding: 0 64px;
+  }
 `;
 
 export const Main = styled.main`
   min-height: 100vh;
-  padding: 4rem 0;
   flex: 1;
   display: flex;
   flex-direction: column;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12651,6 +12651,11 @@ react-textarea-autosize@^8.3.0:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
+react-uuid@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-uuid/-/react-uuid-2.0.0.tgz#e3c97e190db9eef53cb9dacfcc7314d913a411fa"
+  integrity sha512-FNUH/8WR/FEtx0Bu6gmt1eONfc413hhvrEXFWUSFGvznUhI4dYoVZA09p7JHoTpnM4WC2D/bG2YSxGKXF4oVLg==
+
 react@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"


### PR DESCRIPTION
# 概要
simpleカードを横スクロールにするsectionコンポーネントを実装。
` align-items: stretch;`で高さを揃える。

# デモ
<img width="926" alt="スクリーンショット 2023-01-24 14 46 27" src="https://user-images.githubusercontent.com/81739310/214220982-13fbf928-2179-442f-82f3-a24b08cba7f6.png">

# レビューレベル

- [ ] Lv0: まったく見ないでAcceptする

- [ ] Lv1: ぱっとみて違和感がないかチェックしてAcceptする

- [x] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証してAcceptする

- [ ] LV3: 実際に環境で動作確認したうえでAcceptする

# 関連チケット
close #3
close #5 

# 注意点