### PR TITLE
#4 お知らせセクションを追加

### DIFF
--- a/src/components/organisms/SimpleCardSection/index.tsx
+++ b/src/components/organisms/SimpleCardSection/index.tsx
@@ -34,7 +34,7 @@ const SimpleCardWrapper = styled.div`
 export const SimpleCardSection: VFC<SimpleCardSectionProps> = (props) => {
   const { heading, simpleCardArray } = props;
   return (
-    <section>
+    <section >
       <Headline label={heading} headlineTypes="middle" />
       <SimpleCardWrapper>
         {simpleCardArray.map((simpleCardItem: SimpleCardProps) => (

--- a/src/components/organisms/WideCardSection/index.stories.tsx
+++ b/src/components/organisms/WideCardSection/index.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import dayjs from 'dayjs';
+import { WideCardSection } from './index';
+
+export default {
+  component: WideCardSection,
+  title: 'organisms/WideCardSection',
+} as Meta;
+
+type WideCardSectionProps = React.ComponentProps<typeof WideCardSection>;
+
+const Template: Story<WideCardSectionProps> = (args) => (
+  <WideCardSection {...args} />
+);
+
+export const Notice = Template.bind({});
+Notice.args = {
+  heading: 'お知らせ',
+  wideCardArray: [
+    {
+      time: dayjs('2020-12-23'),
+      labels: [
+        {
+          name: '重要',
+          color: '#E20E20',
+        },
+        {
+          name: '新商品',
+          color: '#E89244',
+        },
+        {
+          name: '特別価格',
+          color: '#40AF40',
+        },
+      ],
+      text: 'テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト',
+    },
+    {
+      time: dayjs('2020-12-24'),
+      labels: [
+        {
+          name: '重要',
+          color: '#E20E20',
+        },
+        {
+          name: '特別価格',
+          color: '#40AF40',
+        },
+      ],
+      text: 'テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト',
+    },
+  ],
+};

--- a/src/components/organisms/WideCardSection/index.tsx
+++ b/src/components/organisms/WideCardSection/index.tsx
@@ -1,0 +1,34 @@
+import { VFC } from 'react';
+import { Headline } from 'src/components/atoms/Headline';
+import { WideCard, WideCardProps } from 'src/components/atoms/WideCard';
+import styled from 'styled-components';
+
+export interface WideCardSectionProps {
+  heading: string;
+  wideCardArray: WideCardProps[];
+}
+
+const WideCardWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 16px;
+`;
+
+export const WideCardSection: VFC<WideCardSectionProps> = (props) => {
+  const { heading, wideCardArray } = props;
+  return (
+    <section >
+      <Headline label={heading} headlineTypes="middle" />
+      <WideCardWrapper>
+        {wideCardArray.map((simpleCardItem: WideCardProps) => (
+          <WideCard
+            time={simpleCardItem.time}
+            labels={simpleCardItem.labels}
+            text={simpleCardItem.text}
+          />
+        ))}
+      </WideCardWrapper>
+    </section>
+  );
+};

--- a/src/components/organisms/carousel/index.stories.tsx
+++ b/src/components/organisms/carousel/index.stories.tsx
@@ -1,3 +1,4 @@
+import './image-gallery.css';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Calrousel } from './index';
 

--- a/src/components/organisms/carousel/index.tsx
+++ b/src/components/organisms/carousel/index.tsx
@@ -1,10 +1,8 @@
-import './image-gallery.css';
 import { VFC } from 'react';
 import ImageGallery from 'react-image-gallery';
 
-
 interface CalrouselProps {
-  images: { original: string; }[];
+  images: { original: string }[];
 }
 
 export const Calrousel: VFC<CalrouselProps> = (props) => {

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,5 +1,16 @@
 import uuid from "react-uuid";
 
+export const exampleCalrouselMock = [
+  {
+    original: 'https://picsum.photos/id/1018/1000/600/',
+  },
+  {
+    original: 'https://picsum.photos/id/1015/1000/600/',
+  },
+  {
+    original: 'https://picsum.photos/id/1019/1000/600/',
+  },
+];
 export const exampleCampaignMock = [
   {
     id: uuid(),

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,4 +1,6 @@
 import uuid from "react-uuid";
+import dayjs from 'dayjs';
+import { WideCardProps } from "src/components/atoms/WideCard";
 
 export const exampleCalrouselMock = [
   {
@@ -74,5 +76,40 @@ export const exampleCategoryMock = [
     image: 'https://picsum.photos/id/1019/1000/600/',
     title: 'ゆめみゆめみゆ',
     path: '/shop_items',
+  },
+];
+
+export const exampleNoticeMock:WideCardProps[] = [
+  {
+    time: dayjs('2020-12-23'),
+    labels: [
+      {
+        name: '重要',
+        color: '#E20E20',
+      },
+      {
+        name: '新商品',
+        color: '#E89244',
+      },
+      {
+        name: '特別価格',
+        color: '#40AF40',
+      },
+    ],
+    text: 'テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト',
+  },
+  {
+    time: dayjs('2020-12-24'),
+    labels: [
+      {
+        name: '重要',
+        color: '#E20E20',
+      },
+      {
+        name: '特別価格',
+        color: '#40AF40',
+      },
+    ],
+    text: 'テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト',
   },
 ];

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,8 @@
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import GlobalStyle from 'src/styles/Globals';
+import '../components/organisms/carousel/image-gallery.css';
+
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,17 +1,17 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import Image from 'next/image';
-import uuid from 'react-uuid';
 import { Calrousel } from 'src/components/organisms/carousel';
 import { Header } from 'src/components/organisms/Header';
 import { SimpleCardSection } from 'src/components/organisms/SimpleCardSection';
+import { WideCardSection } from 'src/components/organisms/WideCardSection';
 import {
   exampleCalrouselMock,
   exampleCampaignMock,
   exampleCategoryMock,
+  exampleNoticeMock,
 } from 'src/mocks';
 
-import { Container, Main, Title, TokenTest } from 'src/styles/Home';
+import { Container, Main } from 'src/styles/Home';
 
 const Home: NextPage = () => (
   <>
@@ -32,9 +32,11 @@ const Home: NextPage = () => (
           heading="カテゴリー"
           simpleCardArray={exampleCategoryMock}
         />
+        <WideCardSection
+          heading='お知らせ'
+          wideCardArray={exampleNoticeMock}/>
       </Container>
     </Main>
-    ß
   </>
 );
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,13 +2,16 @@ import type { NextPage } from 'next';
 import Head from 'next/head';
 import Image from 'next/image';
 import uuid from 'react-uuid';
+import { Calrousel } from 'src/components/organisms/carousel';
 import { Header } from 'src/components/organisms/Header';
 import { SimpleCardSection } from 'src/components/organisms/SimpleCardSection';
-import { exampleCampaignMock, exampleCategoryMock } from 'src/mocks';
+import {
+  exampleCalrouselMock,
+  exampleCampaignMock,
+  exampleCategoryMock,
+} from 'src/mocks';
 
 import { Container, Main, Title, TokenTest } from 'src/styles/Home';
-
-
 
 const Home: NextPage = () => (
   <>
@@ -18,10 +21,17 @@ const Home: NextPage = () => (
       <link rel="icon" href="/favicon.ico" />
     </Head>
     <Header />
+    <Calrousel images={exampleCalrouselMock} />
     <Main>
       <Container>
-        <SimpleCardSection heading="キャンペーン" simpleCardArray={exampleCampaignMock} />
-        <SimpleCardSection heading="カテゴリー" simpleCardArray={exampleCategoryMock} />
+        <SimpleCardSection
+          heading="キャンペーン"
+          simpleCardArray={exampleCampaignMock}
+        />
+        <SimpleCardSection
+          heading="カテゴリー"
+          simpleCardArray={exampleCategoryMock}
+        />
       </Container>
     </Main>
     ß

--- a/src/styles/Globals.ts
+++ b/src/styles/Globals.ts
@@ -9,11 +9,16 @@ export default createGlobalStyle`
     margin: 0;
     font-family: ${fonts.NotoSansJP};
     line-height: 1.5;
+    background-color: #eeffee;
   }
 
   a {
     color: inherit;
     text-decoration: none;
+  }
+
+  section{
+    margin-top: 64px;
   }
 
   * {

--- a/src/styles/Home.ts
+++ b/src/styles/Home.ts
@@ -17,7 +17,7 @@ export const Container = styled.div`
 `;
 
 export const Main = styled.main`
-  min-height: 100vh;
+  /* min-height: 100vh; */
   flex: 1;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
# 概要
WideCardコンポーネントからWideCardセクションを実装。Topページに追加

# デモ
<img width="1391" alt="スクリーンショット 2023-01-25 14 48 52" src="https://user-images.githubusercontent.com/81739310/214489921-f63e2bf2-1c70-4ae3-a91e-71007cb5ac22.png">

# レビューレベル

- [ ] Lv0: まったく見ないでAcceptする

- [ ] Lv1: ぱっとみて違和感がないかチェックしてAcceptする

- [x] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証してAcceptする

- [ ] LV3: 実際に環境で動作確認したうえでAcceptする

# 関連チケット
close #4 

# 注意点